### PR TITLE
✨ feat :  Payment service 토스 페이 취소 기능 구현 

### DIFF
--- a/payment-service/src/main/java/gcu/web/paymentservice/common/response/ErrorCode.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/common/response/ErrorCode.java
@@ -17,8 +17,10 @@ public enum ErrorCode {
     // 404 Not Found
     NOT_FOUND_END_POINT(404, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
     // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
 
+    /// 결제
+    NOT_FOUND_EXIST_PAYMENT(5000, HttpStatus.NOT_FOUND, "결제 내역이 존재하지 않습니다."),;
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/in/web/PaymentApi.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/in/web/PaymentApi.java
@@ -8,13 +8,7 @@ import gcu.web.paymentservice.platform.application.in.PaymentUseCase;
 import gcu.web.paymentservice.platform.domain.Payment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.io.IOException;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -37,10 +31,18 @@ public class PaymentApi {
         return ApiResponse.created(PaymentResponse.from(payment), "결제가 정상적으로 성공되었습니다.");
     }
 
-     /// 결제 취소 요청
-    public ApiResponse<String> cancelPayment(@RequestBody CancelPaymentRequest request) throws IOException, InterruptedException {
+    /// 결제 취소 요청
+    @DeleteMapping("/refund")
+    public ApiResponse<String> cancelPayment(@RequestBody CancelPaymentRequest request) throws Exception {
 
-        return null;
+        log.info("cancelPayment called with paymentKey: {}", request.paymentKey());
+
+        // 토스에게 결제 취소 요청
+        paymentService.deletePayment(request);
+
+        // 모임 서비스에게 취소 요청을 보낸다.
+
+        return ApiResponse.ok(null, "취소 되었습니다.");
     }
 
 }

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/PaymentPersistenceAdapter.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/PaymentPersistenceAdapter.java
@@ -34,12 +34,18 @@ public class PaymentPersistenceAdapter implements PaymentPort {
     }
 
     @Override
+    public Optional<Payment> loadPaymentByPaymentKey(String paymentKey) {
+        return repository.findByPaymentKey(paymentKey)
+                .map(PaymentJpaEntity::toDomain);
+    }
+
+    @Override
     public Page<Payment> loadPaymentsByUserId(Long userId, Pageable pageable) {
         return null;
     }
 
     @Override
-    public void deletePayment(String paymentId) {
-
+    public void deletePayment(Long paymentId) {
+        repository.deleteById(paymentId);
     }
 }

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/jpa/payment/PaymentJpaRepository.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/jpa/payment/PaymentJpaRepository.java
@@ -2,5 +2,10 @@ package gcu.web.paymentservice.platform.adapter.out.jpa.payment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentJpaRepository extends JpaRepository<PaymentJpaEntity, Long> {
+
+    Optional<PaymentJpaEntity> findByPaymentKey(String paymentKey);
+
 }

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/pg/toss/TossPaymentAdapter.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/pg/toss/TossPaymentAdapter.java
@@ -58,15 +58,21 @@ public class TossPaymentAdapter implements PaymentExternalPort {
     /// 결제 취소 요청
     public HttpResponse<String> requestPaymentCancel(String paymentKey, String cancelReason) throws IOException, InterruptedException {
         System.out.println(paymentKey);
+
+        // 승인 요청에 사용할 JSON 객체 생성
+        JsonNode requestObj = objectMapper.createObjectNode()
+                .put("cancelReason", cancelReason);  // paymentKey는 URL에 포함되어 있으므로 요청 바디에 포함할 필요 없음
+
+        String requestBody = objectMapper.writeValueAsString(requestObj);  // JSON 문자열로 변환
+
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.tosspayments.com/v1/payments/" + paymentKey + "/cancel"))
                 .header("Authorization", authorizations)
                 .header("Content-Type", "application/json")
-                .method("POST", HttpRequest.BodyPublishers.ofString("cancelReason:" + cancelReason))
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                 .build();
+
         return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-
-
     }
 
 }

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/in/PaymentUseCase.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/in/PaymentUseCase.java
@@ -6,6 +6,8 @@ import gcu.web.paymentservice.platform.domain.Payment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.io.IOException;
+
 public interface PaymentUseCase {
 
     /*
@@ -25,7 +27,7 @@ public interface PaymentUseCase {
     Page<Payment> findMyPayments(Long memberId, Pageable pageable);
 
     /// 결제 취소
-    void deletePayment(CancelPaymentRequest request);
+    void deletePayment(CancelPaymentRequest request) throws IOException, InterruptedException;
 
 
 }

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/out/PaymentPort.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/out/PaymentPort.java
@@ -15,9 +15,11 @@ public interface PaymentPort {
     // 결제 상세 조회
     Optional<Payment> loadPayment(Long id);
 
+    Optional<Payment> loadPaymentByPaymentKey(String paymentKey);
+
     // 유저 아이디 바탕 결제 조회
     Page<Payment> loadPaymentsByUserId(Long userId, Pageable pageable);
 
     // 결제 삭제
-    void deletePayment(String paymentId);
+    void deletePayment(Long paymentId);
 }


### PR DESCRIPTION
## 📌 작업한 내용
토스페이 서버 결제 취소 기능 구현

## 🔍 참고 사항
- 결제가 완료된 paymentKey를 통해서만 취소가 가능합니다.
- 현재는 취소이유를 string으로 했는데 enum으로 바꿔도 좋을것 같습니다

## 🖼️ 스크린샷
### DB에 존재하는 결제 목록
<img width="1502" alt="스크린샷 2025-05-09 21 46 38" src="https://github.com/user-attachments/assets/f7eb6814-d9a1-4a11-ba7c-e96c7590a97a" />


### API 호출로 사용하는 결제 취소
<img width="1502" alt="스크린샷 2025-05-09 21 46 44" src="https://github.com/user-attachments/assets/eba548d5-b422-4cc6-9613-38d614675222" />

### DB 상에서 사라진 값
<img width="1502" alt="스크린샷 2025-05-09 21 46 52" src="https://github.com/user-attachments/assets/ae8ae661-bc8b-4273-b59c-cd5b9a43744c" />


## 🔗 관련 이슈

## ✅ 체크리스트
[] 로컬에서 빌드 및 테스트 완료
[] 코드 리뷰 반영 완료
[] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 결제 내역이 존재하지 않을 때를 위한 새로운 오류 코드가 추가되었습니다.
    - 결제 취소(환불) API 엔드포인트가 추가되어, 결제 취소 요청이 가능합니다.

- **버그 수정**
    - 결제 취소 시 요청 본문이 올바른 JSON 형식으로 전송되도록 개선되었습니다.
    - 결제 취소 시 결제 내역이 존재하지 않을 경우 명확한 오류 메시지가 반환됩니다.

- **기타 개선**
    - 결제 취소 처리 과정에서 상세한 예외 및 오류 처리가 추가되었습니다.
    - 일부 메서드의 파라미터 타입 및 예외 처리 방식이 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->