### PR TITLE
✨feat : Payment service/feature/주문 연동

### DIFF
--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.5'
+    id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2021.0.5")
+    set('springCloudVersion', "2023.0.1")
 }
 
 
@@ -40,6 +40,7 @@ dependencies {
 
     /// JPA
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
 
     /// Test

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -23,14 +23,34 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2021.0.5")
+}
+
+
 dependencies {
+
+    /// 기본 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    /// FeignClient
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
+
+    /// JPA
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
+    /// Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/payment-service/src/main/java/gcu/web/paymentservice/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/PaymentServiceApplication.java
@@ -2,8 +2,10 @@ package gcu.web.paymentservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class PaymentServiceApplication {
 
     public static void main(String[] args) {

--- a/payment-service/src/main/java/gcu/web/paymentservice/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/PaymentServiceApplication.java
@@ -4,12 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@SpringBootApplication
 @EnableFeignClients
+@SpringBootApplication
 public class PaymentServiceApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(PaymentServiceApplication.class, args);
     }
-
 }
+

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/external/order/OrderFeignPort.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/external/order/OrderFeignPort.java
@@ -1,0 +1,22 @@
+package gcu.web.paymentservice.platform.adapter.out.external.order;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+
+@FeignClient(name="ORDER-SERVICE", path="order-service")
+public interface OrderFeignPort {
+
+    /*
+       - 오더 서비스에게 메세지 전송을 하는 포트를 정의한다.
+     */
+
+    @PostMapping("/api/v1/orders/{orderId}/cancel")
+    String cancelOrder(@PathVariable String orderId);
+
+    @PostMapping("/api/v1/orders/{orderId}")
+    String completeOrder(@PathVariable String orderId);
+
+
+}

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/external/order/OrderFeignPort.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/external/order/OrderFeignPort.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 
-@FeignClient(name="ORDER-SERVICE", path="order-service")
+@FeignClient(name = "order-service", url = "http://localhost:8081")
 public interface OrderFeignPort {
 
     /*
@@ -13,10 +13,10 @@ public interface OrderFeignPort {
      */
 
     @PostMapping("/api/v1/orders/{orderId}/cancel")
-    String cancelOrder(@PathVariable String orderId);
+    String cancelOrder(@PathVariable("orderId") String orderId);
 
     @PostMapping("/api/v1/orders/{orderId}")
-    String completeOrder(@PathVariable String orderId);
-
+    String completeOrder(@PathVariable("orderId") String orderId);
 
 }
+

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/pg/toss/TossPaymentAdapter.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/adapter/out/pg/toss/TossPaymentAdapter.java
@@ -3,7 +3,7 @@ package gcu.web.paymentservice.platform.adapter.out.pg.toss;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.ConfirmPaymentRequest;
-import gcu.web.paymentservice.platform.application.out.PaymentExternalPort;
+import gcu.web.paymentservice.platform.application.out.pg.PaymentExternalPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/out/pg/PaymentExternalPort.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/out/pg/PaymentExternalPort.java
@@ -1,4 +1,4 @@
-package gcu.web.paymentservice.platform.application.out;
+package gcu.web.paymentservice.platform.application.out.pg;
 
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.ConfirmPaymentRequest;
 

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
@@ -24,7 +24,6 @@ import java.net.http.HttpResponse;
 @Slf4j
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class PaymentService implements PaymentUseCase {
 
     private final ObjectMapper objectMapper;
@@ -37,6 +36,13 @@ public class PaymentService implements PaymentUseCase {
 
     // 주문 서비스 연동
     private final OrderFeignPort orderFeignPort;
+
+    public PaymentService(ObjectMapper objectMapper, PaymentPort paymentPort, PaymentExternalPort pgPort, OrderFeignPort orderFeignPort) {
+        this.objectMapper = objectMapper;
+        this.paymentPort = paymentPort;
+        this.pgPort = pgPort;
+        this.orderFeignPort = orderFeignPort;
+    }
 
 
     // 리액트에게 결과 리턴

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
@@ -6,7 +6,7 @@ import gcu.web.paymentservice.common.response.ErrorCode;
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.CancelPaymentRequest;
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.ConfirmPaymentRequest;
 import gcu.web.paymentservice.platform.application.in.PaymentUseCase;
-import gcu.web.paymentservice.platform.application.out.PaymentExternalPort;
+import gcu.web.paymentservice.platform.application.out.pg.PaymentExternalPort;
 import gcu.web.paymentservice.platform.application.out.PaymentPort;
 import gcu.web.paymentservice.platform.domain.Payment;
 import gcu.web.paymentservice.platform.domain.PaymentStatus;

--- a/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
+++ b/payment-service/src/main/java/gcu/web/paymentservice/platform/application/service/PaymentService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gcu.web.paymentservice.common.response.ErrorCode;
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.CancelPaymentRequest;
 import gcu.web.paymentservice.platform.adapter.in.web.dto.request.ConfirmPaymentRequest;
+import gcu.web.paymentservice.platform.adapter.out.external.order.OrderFeignPort;
 import gcu.web.paymentservice.platform.application.in.PaymentUseCase;
 import gcu.web.paymentservice.platform.application.out.pg.PaymentExternalPort;
 import gcu.web.paymentservice.platform.application.out.PaymentPort;
@@ -34,6 +35,8 @@ public class PaymentService implements PaymentUseCase {
     // 외부 토스 의존
     private final PaymentExternalPort pgPort;
 
+    // 주문 서비스 연동
+    private final OrderFeignPort orderFeignPort;
 
 
     // 리액트에게 결과 리턴
@@ -50,7 +53,13 @@ public class PaymentService implements PaymentUseCase {
         if (response.statusCode() == 200) {
             // 객체 저장
             Payment payment = createPayment(confirmPaymentRequest, responseBody);
-            return paymentPort.savePayment(payment);
+
+            Payment saved = paymentPort.savePayment(payment);
+
+            // 주문 정보 전달
+            orderFeignPort.completeOrder(saved.getOrderId());
+
+            return saved;
 
         } else {
             log.error("response status code: {}", response.statusCode());
@@ -82,6 +91,9 @@ public class PaymentService implements PaymentUseCase {
 
             // 객체 삭제
             paymentPort.deletePayment(payment.getId());
+
+            // 주문 취소 정보 전달
+            orderFeignPort.cancelOrder(payment.getOrderId());
 
         } else {
             log.error("response status code: {}", response.statusCode());

--- a/payment-service/src/test/java/gcu/web/paymentservice/PaymentServiceApplicationTests.java
+++ b/payment-service/src/test/java/gcu/web/paymentservice/PaymentServiceApplicationTests.java
@@ -3,7 +3,6 @@ package gcu.web.paymentservice;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class PaymentServiceApplicationTests {
 
     @Test


### PR DESCRIPTION
### 개요
- 주문 서비스 연동

### PR 내용
- Spring Boot 3.4.5는 Spring Cloud와 아직 호환되지 않습니다.
- Spring 버전 낮추기
- 현재 오더 서비스의 주소를 몰라 8081 포트로 진행했습니다.

### 참고 사항
- OrderId는 UUID 형태의 Stirng로 부탁드립니다!
- 주문 서비스에서 결제 후, 결제 상태를 변화시키는 코드가 필요합니다.
- 결제 완료, 결제 취소

### 스크린샷
<img width="1400" alt="스크린샷 2025-05-16 16 48 17" src="https://github.com/user-attachments/assets/50e1b99f-3c36-4730-a284-d23e21a55e7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 결제 서비스가 외부 주문 서비스와 연동되어 결제 완료 시 주문 완료 알림, 결제 취소 시 주문 취소 알림을 전송합니다.

- **버그 수정**
    - 테스트 코드에서 전체 스프링 컨텍스트 로딩이 제거되어 테스트 실행 속도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->