### PR TITLE
fix: h2 의존성  수정

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.h2database:h2'
+	testImplementation 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## h2 의존성 수정
- testImplementation 로 의존성 추가  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - H2 데이터베이스 의존성이 테스트 환경에서만 적용되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->