### PR TITLE
fix: 메뉴 등록 시 가격 검증 수정

### DIFF
--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     // OpenAPI + Validation
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 
     // Lombok + MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/store-service/src/main/java/com/example/storeservice/controller/MenuController.java
+++ b/store-service/src/main/java/com/example/storeservice/controller/MenuController.java
@@ -33,7 +33,7 @@ public class MenuController {
     public ResponseEntity<BaseResponse<Void>> updateMenuPartially(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
-            @RequestBody MenuPartialUpdateDto updateDto) {
+            @RequestBody @Valid MenuPartialUpdateDto updateDto) {
         menuService.updateMenuPartially(menuId, updateDto);
         return ResponseEntity.ok(BaseResponse.success(null));
     }

--- a/store-service/src/main/java/com/example/storeservice/controller/StoreController.java
+++ b/store-service/src/main/java/com/example/storeservice/controller/StoreController.java
@@ -1,8 +1,10 @@
 package com.example.storeservice.controller;
 
 import com.example.storeservice.dto.StoreRequestDto;
+import com.example.storeservice.dto.StoreResponseDto;
 import com.example.storeservice.entity.Store;
 import com.example.storeservice.service.StoreService;
+import com.example.storeservice.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import java.util.HashMap;
 import java.util.Map;
 import com.example.storeservice.dto.StoreUpdateDto;
-import com.example.storeservice.response.BaseResponse;
+import java.util.List;
 
 
 @RestController
@@ -26,11 +28,22 @@ public class StoreController {
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> createStore(@Valid @RequestBody StoreRequestDto requestDto) {
         storeService.createStore(requestDto);
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(BaseResponse.success(null));
+        return ResponseEntity.ok(BaseResponse.success(null));
     }
 
+    @GetMapping("/{storeId}")
+    @Operation(summary = "단일 가게 조회", description = "storeId에 해당하는 가게의 상세 정보를 조회합니다.")
+    public ResponseEntity<BaseResponse<StoreResponseDto>> getStoreById(@PathVariable Long storeId) {
+        StoreResponseDto store = storeService.getStoreById(storeId);
+        return ResponseEntity.ok(BaseResponse.success(store));
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 가게 목록 조회", description = "등록된 모든 가게 정보를 조회합니다.")
+    public ResponseEntity<BaseResponse<List<StoreResponseDto>>> getAllStores() {
+        List<StoreResponseDto> stores = storeService.getAllStores();
+        return ResponseEntity.ok(BaseResponse.success(stores));
+    }
 
     @PatchMapping("/{storeId}")
     @Operation(summary = "가게 정보 수정", description = "가게의 일부 정보를 수정합니다.")

--- a/store-service/src/main/java/com/example/storeservice/dto/MenuPartialUpdateDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/MenuPartialUpdateDto.java
@@ -1,6 +1,7 @@
 package com.example.storeservice.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ public class MenuPartialUpdateDto {
     private String name;
 
     @Schema(description = "메뉴 가격", example = "8500")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
     private Integer price;
 
     @Schema(description = "메뉴 설명", example = "매콤한 신메뉴 짜장면")

--- a/store-service/src/main/java/com/example/storeservice/dto/MenuRequestDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/MenuRequestDto.java
@@ -19,9 +19,9 @@ public class MenuRequestDto {
     private String name;
 
     @Schema(description = "메뉴 가격 (원)", example = "7500")
-    @NotBlank(message = "가격은 필수입니다.")
+    @NotNull(message = "가격은 필수입니다.")
     @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
-    private int price;
+    private Integer price;
 
     @Schema(description = "메뉴 설명", example = "고소하고 담백한 참치마요 덮밥")
     @NotBlank(message = "메뉴 설명은 필수입니다.")
@@ -33,7 +33,4 @@ public class MenuRequestDto {
     )
     private Map<String, List<String>> options;
 
-    @Schema(description = "메뉴 이미지 URL", example = "https://cdn.example.com/images/menu1.jpg")
-    private String imageUrl;
 }
-

--- a/store-service/src/main/java/com/example/storeservice/dto/StoreResponseDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/StoreResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.storeservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreResponseDto {
+    private Long id;
+    private String name;
+    private String phone;
+    private String location;
+    private String description;
+    private String openHours;
+    private Integer minOrderPrice;
+} 

--- a/store-service/src/main/java/com/example/storeservice/exception/GlobalExceptionHandler.java
+++ b/store-service/src/main/java/com/example/storeservice/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.example.storeservice.exception;
 import com.example.storeservice.response.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,6 +16,14 @@ public class GlobalExceptionHandler {
         ErrorCode code = ex.getErrorCode();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(BaseResponse.fail(code));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<Object>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        String errorMessage = fieldError != null ? fieldError.getDefaultMessage() : "잘못된 요청입니다.";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(BaseResponse.fail(ErrorCode.INVALID_REQUEST, errorMessage));
     }
 
     @ExceptionHandler(Exception.class)

--- a/store-service/src/main/java/com/example/storeservice/mapper/StoreMapper.java
+++ b/store-service/src/main/java/com/example/storeservice/mapper/StoreMapper.java
@@ -1,6 +1,7 @@
 package com.example.storeservice.mapper;
 
 import com.example.storeservice.dto.StoreRequestDto;
+import com.example.storeservice.dto.StoreResponseDto;
 import com.example.storeservice.entity.Store;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -8,6 +9,6 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface StoreMapper {
     Store toEntity(StoreRequestDto dto);
-    StoreRequestDto toDto(Store entity);
-    
+    StoreRequestDto toRequestDto(Store entity);
+    StoreResponseDto toResponseDto(Store store);
 }

--- a/store-service/src/main/java/com/example/storeservice/response/BaseResponse.java
+++ b/store-service/src/main/java/com/example/storeservice/response/BaseResponse.java
@@ -23,15 +23,14 @@ public class BaseResponse<T> {
     
 
     public static <T> BaseResponse<T> success(T data) {
-        return new BaseResponse<T>(true, 1000, "요청에 성공했습니다.", data);
+        return new BaseResponse<T>(true, 200, "성공", data);
     }
 
-    public static BaseResponse<Object> fail(ErrorCode errorCode) {
-        return new BaseResponse<>(
-                errorCode.isSuccess(),
-                errorCode.getCode(),
-                errorCode.getMessage(),
-                null
-        );
+    public static <T> BaseResponse<T> fail(ErrorCode errorCode) {
+        return new BaseResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> BaseResponse<T> fail(ErrorCode errorCode, String message) {
+        return new BaseResponse<>(false, errorCode.getCode(), message, null);
     }
 }

--- a/store-service/src/main/java/com/example/storeservice/service/MenuService.java
+++ b/store-service/src/main/java/com/example/storeservice/service/MenuService.java
@@ -45,9 +45,8 @@ public class MenuService {
         Menu menu = menuMapper.toEntity(dto);
         menu.setStore(store);
 
-        // 4. 먼저 Menu 저장해서 menu.id 생성
+        // 4. Menu 저장
         menu = menuRepository.save(menu);
-
     }
 
 

--- a/store-service/src/main/java/com/example/storeservice/service/StoreService.java
+++ b/store-service/src/main/java/com/example/storeservice/service/StoreService.java
@@ -10,6 +10,9 @@ import com.example.storeservice.dto.StoreUpdateDto;
 import org.springframework.transaction.annotation.Transactional;
 import com.example.storeservice.exception.CustomException;
 import com.example.storeservice.exception.ErrorCode;
+import com.example.storeservice.dto.StoreResponseDto;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -80,7 +83,7 @@ public class StoreService {
         }
     }
 
-
+    // 가게 삭제
     @Transactional
     public void deleteStore(Long storeId) {
         Store store = storeRepository.findById(storeId)
@@ -88,5 +91,20 @@ public class StoreService {
         storeRepository.delete(store);
     }
 
+    // 가게 조회
+    @Transactional(readOnly = true)
+    public StoreResponseDto getStoreById(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        return storeMapper.toResponseDto(store);
+    }
 
+    // 전체 가게 조회
+    @Transactional(readOnly = true)
+    public List<StoreResponseDto> getAllStores() {
+        List<Store> stores = storeRepository.findAll();
+        return stores.stream()
+            .map(storeMapper::toResponseDto)
+            .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
메뉴 등록 시 가격 검증 오류 수정
기존 가격 검증에서 음수로 등록시 예외 처리 안함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 매장 단일 조회 및 전체 목록 조회 API가 추가되었습니다.
  - 매장 정보를 반환하는 새로운 응답 DTO가 도입되었습니다.

- **버그 수정**
  - 메뉴 가격 필드의 유효성 검사가 강화되어, 0원 미만 입력 시 오류 메시지가 제공됩니다.
  - 메뉴 요청 시 가격 필드의 검증 방식이 올바르게 수정되었습니다.

- **개선 사항**
  - 유효성 검증 실패 시, 보다 명확한 오류 메시지와 함께 400 오류가 반환됩니다.
  - 메뉴 부분 수정 요청 시 유효성 검사가 적용됩니다.
  - 매장 생성 시 응답 코드가 201에서 200으로 변경되었습니다.
  - 공통 응답 메시지 및 오류 응답 방식이 개선되었습니다.

- **기타**
  - 일부 불필요한 필드(메뉴 이미지 URL)가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->