### PR TITLE
feat : 가게 카테고리 추가 및 옵션 형식 변경

### DIFF
--- a/store-service/src/main/java/com/example/storeservice/dto/MenuPartialUpdateDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/MenuPartialUpdateDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Map;
 
 @Getter
 @Setter
@@ -24,9 +23,17 @@ public class MenuPartialUpdateDto {
     @Schema(description = "메뉴 설명", example = "매콤한 신메뉴 짜장면")
     private String description;
 
-    @Schema(description = "메뉴 옵션", example = "{\"맛\": [\"순한맛\", \"매운맛\"]}")
-    private Map<String, List<String>> options;
+    @Schema(description = "메뉴 옵션", example = "[{\"id\": \"1\", \"name\": \"곱빼기\", \"price\": 2000}, {\"id\": \"2\", \"name\": \"매운맛\", \"price\": 1000}]")
+    private List<OptionInfo> options;
 
     @Schema(description = "이미지 URL", example = "https://cdn.example.com/menu.jpg")
     private String imageUrl;
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class OptionInfo {
+        private String id;
+        private String name;
+        private Integer price;
+    }
 }

--- a/store-service/src/main/java/com/example/storeservice/dto/MenuRequestDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/MenuRequestDto.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import java.util.List;
-import java.util.Map;
-
 
 @Getter
 @Setter
@@ -29,8 +27,27 @@ public class MenuRequestDto {
 
     @Schema(
         description = "메뉴 옵션",
-        example = "{\"맛\": [\"순한맛\", \"매운맛\"], \"사이즈\": [\"보통\", \"곱빼기\"]}"
+        example = "[{\"id\": \"1\", \"name\": \"곱빼기\", \"price\": 2000}, {\"id\": \"2\", \"name\": \"매운맛\", \"price\": 1000}]"
     )
-    private Map<String, List<String>> options;
+    private List<OptionInfo> options;
 
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+    private String imageUrl;
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class OptionInfo {
+        @Schema(description = "옵션 ID", example = "1")
+        @NotBlank(message = "옵션 ID는 필수입니다.")
+        private String id;
+
+        @Schema(description = "옵션 이름", example = "곱빼기")
+        @NotBlank(message = "옵션 이름은 필수입니다.")
+        private String name;
+
+        @Schema(description = "옵션 가격", example = "2000")
+        @NotNull(message = "옵션 가격은 필수입니다.")
+        @Min(value = 0, message = "옵션 가격은 0원 이상이어야 합니다.")
+        private Integer price;
+    }
 }

--- a/store-service/src/main/java/com/example/storeservice/dto/MenuResponseDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/MenuResponseDto.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Map;
 
 @Getter
 @Setter
@@ -20,5 +19,13 @@ public class MenuResponseDto {
     private Integer discountedPrice;   // 할인 적용된 가격 (예: 8000)
 
     private String imageUrl;
-    private Map<String, List<String>> options;
+    private List<OptionInfo> options;
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class OptionInfo {
+        private String id;
+        private String name;
+        private Integer price;
+    }
 }

--- a/store-service/src/main/java/com/example/storeservice/dto/StoreRequestDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/StoreRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.storeservice.dto;
 
+import com.example.storeservice.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
@@ -34,4 +35,8 @@ public class StoreRequestDto {
     @Schema(description = "최소 주문 금액", example = "10000", required = true)
     @Min(value = 0, message = "최소 주문 금액은 0 이상이어야 합니다.")
     private int minOrderPrice;
+
+    @Schema(description = "가게 카테고리", example = "KOREAN", required = true)
+    @NotNull(message = "카테고리는 필수입니다.")
+    private Category category;
 }

--- a/store-service/src/main/java/com/example/storeservice/dto/StoreResponseDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/StoreResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.storeservice.dto;
 
+import com.example.storeservice.entity.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +18,5 @@ public class StoreResponseDto {
     private String description;
     private String openHours;
     private Integer minOrderPrice;
+    private Category category;
 } 

--- a/store-service/src/main/java/com/example/storeservice/dto/StoreUpdateDto.java
+++ b/store-service/src/main/java/com/example/storeservice/dto/StoreUpdateDto.java
@@ -1,5 +1,6 @@
 package com.example.storeservice.dto;
 
+import com.example.storeservice.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,4 +28,7 @@ public class StoreUpdateDto {
 
     @Schema(description = "최소 주문 금액", example = "15000")
     private Integer minOrderPrice;
+
+    @Schema(description = "가게 카테고리", example = "KOREAN")
+    private Category category;
 }

--- a/store-service/src/main/java/com/example/storeservice/entity/Category.java
+++ b/store-service/src/main/java/com/example/storeservice/entity/Category.java
@@ -1,0 +1,26 @@
+package com.example.storeservice.entity;
+
+public enum Category {
+    FAST_FOOD("패스트푸드"),
+    KOREAN("한식"),
+    SNACK("분식"),
+    CHICKEN("치킨"),
+    SOUP("찜/탕"),
+    JAPANESE("일식"),
+    MEAT("고기"),
+    PORK_CUTLET("돈까스/회"),
+    PIZZA("피자"),
+    CAFE("카페/디저트"),
+    SALAD("샐러드"),
+    CHINESE("중식");
+
+    private final String displayName;
+
+    Category(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+} 

--- a/store-service/src/main/java/com/example/storeservice/entity/Menu.java
+++ b/store-service/src/main/java/com/example/storeservice/entity/Menu.java
@@ -4,8 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
+import java.util.ArrayList;
 
 @Entity
 @Getter @Setter
@@ -21,8 +20,10 @@ public class Menu {
     private String description;
 
     @ElementCollection
-    private Map<String, List<String>> options = new HashMap<>();
-
+    @CollectionTable(name = "menu_options", joinColumns = @JoinColumn(name = "menu_id"))
+    @OrderColumn(name = "options_index")
+    private List<OptionInfo> options = new ArrayList<>();
+    
 
     private String imageUrl;
 
@@ -32,4 +33,13 @@ public class Menu {
 
     @OneToOne(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
     private MenuDiscount menuDiscount;
+
+    @Embeddable
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class OptionInfo {
+        private String id;
+        private String name;
+        private Integer price;
+    }
 }

--- a/store-service/src/main/java/com/example/storeservice/entity/MenuDiscount.java
+++ b/store-service/src/main/java/com/example/storeservice/entity/MenuDiscount.java
@@ -15,10 +15,11 @@ public class MenuDiscount {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
 
     @Column(nullable = false)
-    private int discountRate;  // ex: 20 (20%)
+    private int discountRate;
 }
+

--- a/store-service/src/main/java/com/example/storeservice/entity/Store.java
+++ b/store-service/src/main/java/com/example/storeservice/entity/Store.java
@@ -20,6 +20,10 @@ public class Store {
     private String openHours;
     @Column(nullable = false)
     private int minOrderPrice;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Menu> menus = new ArrayList<>();
@@ -31,6 +35,7 @@ public class Store {
     public String getDescription() { return description; }
     public String getOpenHours() { return openHours; }
     public int getMinOrderPrice() { return minOrderPrice; }
+    public Category getCategory() { return category; }
 
     public void setName(String name) { this.name = name; }
     public void setPhone(String phone) { this.phone = phone; }
@@ -38,4 +43,5 @@ public class Store {
     public void setDescription(String description) { this.description = description; }
     public void setOpenHours(String openHours) { this.openHours = openHours; }
     public void setMinOrderPrice(int minOrderPrice) { this.minOrderPrice = minOrderPrice; }
+    public void setCategory(Category category) { this.category = category; }
 }

--- a/store-service/src/main/java/com/example/storeservice/mapper/MenuMapper.java
+++ b/store-service/src/main/java/com/example/storeservice/mapper/MenuMapper.java
@@ -2,18 +2,47 @@ package com.example.storeservice.mapper;
 
 import com.example.storeservice.dto.MenuRequestDto;
 import com.example.storeservice.dto.MenuResponseDto;
+import com.example.storeservice.dto.MenuPartialUpdateDto;
 import com.example.storeservice.entity.Menu;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface MenuMapper {
 
     @Mapping(target = "id", ignore = true)      // 생성 시 ID는 자동 생성
     @Mapping(target = "store", ignore = true)   // service 계층에서 주입
+    @Mapping(target = "menuDiscount", ignore = true)
     Menu toEntity(MenuRequestDto dto);
 
     @Mapping(target = "discountRate", ignore = true)
     @Mapping(target = "discountedPrice", ignore = true)
     MenuResponseDto toDto(Menu menu);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "store", ignore = true)
+    @Mapping(target = "menuDiscount", ignore = true)
+    Menu toEntity(MenuPartialUpdateDto dto);
+
+    @Named("mapOptionInfo")
+    default Menu.OptionInfo mapOptionInfo(MenuPartialUpdateDto.OptionInfo optionInfo) {
+        if (optionInfo == null) {
+            return null;
+        }
+        Menu.OptionInfo mapped = new Menu.OptionInfo();
+        mapped.setId(optionInfo.getId());
+        mapped.setName(optionInfo.getName());
+        mapped.setPrice(optionInfo.getPrice());
+        return mapped;
+    }
+    @Named("mapOptionInfoList")
+    default List<Menu.OptionInfo> mapOptionInfoList(List<MenuPartialUpdateDto.OptionInfo> optionInfos) {
+        if (optionInfos == null) return null;
+        return optionInfos.stream()
+            .map(this::mapOptionInfo)
+            .toList();
+    }
+
 }

--- a/store-service/src/main/java/com/example/storeservice/service/MenuService.java
+++ b/store-service/src/main/java/com/example/storeservice/service/MenuService.java
@@ -1,7 +1,7 @@
 package com.example.storeservice.service;
 
 import com.example.storeservice.dto.MenuRequestDto;
-import com.example.storeservice.dto.MenuPartialUpdateDto;
+import com.example.storeservice.dto.MenuResponseDto;
 import com.example.storeservice.entity.Menu;
 import com.example.storeservice.entity.Store;
 import com.example.storeservice.exception.CustomException;
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
-import com.example.storeservice.dto.MenuResponseDto;
+import com.example.storeservice.dto.MenuPartialUpdateDto;
 import com.example.storeservice.repository.MenuDiscountRepository;
-
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -45,10 +45,12 @@ public class MenuService {
         Menu menu = menuMapper.toEntity(dto);
         menu.setStore(store);
 
+        if (dto.getOptions() == null) {
+            menu.setOptions(new ArrayList<>());
+        }
         // 4. Menu 저장
         menu = menuRepository.save(menu);
     }
-
 
     /**
      * 메뉴 부분 수정
@@ -76,7 +78,7 @@ public class MenuService {
         }
 
         if (dto.getOptions() != null) {
-            menu.setOptions(dto.getOptions());
+            menu.setOptions(menuMapper.mapOptionInfoList(dto.getOptions()));
         }
 
         if (dto.getImageUrl() != null && !dto.getImageUrl().isBlank()) {
@@ -108,13 +110,11 @@ public class MenuService {
         menuRepository.deleteAll(menus);
     }
 
-
     /**
      * 메뉴 전체 불러오기
      */
     @Transactional(readOnly = true)
     public List<MenuResponseDto> getMenusByStoreId(Long storeId) {
-        
         Store store = storeRepository.findById(storeId)
             .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
 
@@ -134,5 +134,4 @@ public class MenuService {
             })
             .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
## 📌 작업한 내용  
- store에 카테고리 추가 
    FAST_FOOD("패스트푸드"),
    KOREAN("한식"),
    SNACK("분식"),
    CHICKEN("치킨"),
    SOUP("찜/탕"),
    JAPANESE("일식"),
    MEAT("고기"),
    PORK_CUTLET("돈까스/회"),
    PIZZA("피자"),
    CAFE("카페/디저트"),
    SALAD("샐러드"),
    CHINESE("중식");
    
- 메뉴의 Option 형식 변경
        private String id;
        private String name;
        private Integer price;


## 🔍 참고 사항  


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
로컬에서 빌드할 때 어려웠던 부분이
기존 DB 형식과 달라서 테스트 할 때 기존 DB 지우고 JPA로 새로 생성해서 해야합니다.

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 가게와 메뉴에 카테고리(enum) 필드가 추가되어 다양한 음식 카테고리를 지정할 수 있습니다.
    - 메뉴에 이미지 URL 필드가 추가되었습니다.

- **변경 사항**
    - 메뉴 옵션 구조가 기존 Map에서 id, 이름, 가격 정보를 갖는 리스트 형태로 변경되었습니다.
    - 관련 API 응답 및 요청 데이터 형식이 새로운 옵션 구조를 반영하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->